### PR TITLE
Updated to match rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
   <img width="500px" src="https://github.com/notsniped/stock-webpage/blob/main/assets/Stock%20(Dark).jpg?raw=true">
 </p>
 
-# Stock, the future of isobot.
-![LICENSE](https://img.shields.io/github/license/notsniped/stock-bot)
+# Isobot lazer, the future of isobot.
+![LICENSE](https://img.shields.io/github/license/notsniped/isobot-lazer)
 [![Discord](https://img.shields.io/discord/880409977074888714?color=%235865F2&label=Discord&logo=discord&logoColor=%23fff)](https://discord.gg/b5pz8T6Yjr)
 
-![Stars](https://img.shields.io/github/stars/notsniped/stock-bot?style=social)
+![Stars](https://img.shields.io/github/stars/notsniped/isobot-lazer?style=social)
 
-Stock is a project developed by the PBD organization, as a version of isobot which is sharper than beta.
+Isobot lazer is a brand-new project developed by the PBD organization, as a version of isobot which is sharper than beta.
 
 This open-source project is supposed to represent what the next-generation of isobot will look like, and how it will progress into the future.
 
 ## Why a new project?
-I wanted to make brand new, cutting-edge features for isobot. But in the process, I ran into some serious codeblocks which prevented me from doing so. This is why I decided to completely rewrite isobot as codename 'Stock' which is much more future-proof.
+I wanted to make brand new, cutting-edge features for isobot. But in the process, I ran into some serious codeblocks which prevented me from doing so. This is why I decided to completely rewrite isobot as codename 'lazer' which is much more future-proof.
 
 ## How can I help?
 Well, you can make pull requests for new features, and submit current issues, which would help improve the development process!
@@ -22,7 +22,7 @@ Well, you can make pull requests for new features, and submit current issues, wh
 Never- I mean, yes
 
 ## When the project's development is complete, what will happen?
-I don't expect the project development to ever complete. But at some point, we might merge these changes with [isobot](https://github.com/PyBotDevs/isobot-python) sooner or later.
+I don't expect the project development to ever fully complete. But at some point, we might merge these changes with [our main project](https://github.com/PyBotDevs/isobot-python) sooner or later.
 
 # Invite link
 The project doesn't seem ready enough to add the link. We will update this when it is.


### PR DESCRIPTION
Removes all mentions of 'stock' and replace it with 'Isobot lazer'.