### PR TITLE
Log stuff to console

### DIFF
--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,19 +1,22 @@
 import time
 import datetime
-log_path = "./Desktop/Stock/logs/info-log.txt"
-error_path = "./Desktop/Stock/logs/info-log.txt"
+log_path = "/home/notsniped/Desktop/Stock/logs/info-log.txt"
+error_path = "/home/notsniped/Desktop/Stock/logs/info-log.txt"
 def info(text:str):
     current_time = datetime.datetime.now().strftime("%H:%M:%S")
+    f.write(f'[{current_time}/INFO] {text}.')
     with open(log_path, 'a') as f:
         f.write(f'[{current_time}/INFO] {text}.\n')
         f.close()
 def warn(text:str):
     current_time = datetime.datetime.now().strftime("%H:%M:%S")
+    f.write(f'[{current_time}/WARN] {text}.')
     with open(log_path, 'a') as f:
         f.write(f'[{current_time}/WARN] {text}.\n')
         f.close()
 def error(text:str):
     current_time = datetime.datetime.now().strftime("%H:%M:%S")
+    f.write(f'[{current_time}/ERROR] {text}.')
     with open(error_path, 'a') as f:
         f.write(f'[{current_time}/ERROR] {text}.\n')
         f.close()

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,7 +1,7 @@
 import time
 import datetime
-log_path = "/home/notsniped/Desktop/Stock/logs/info-log.txt"
-error_path = "/home/notsniped/Desktop/Stock/logs/info-log.txt"
+log_path = "./Desktop/Stock/logs/info-log.txt"
+error_path = "./Desktop/Stock/logs/info-log.txt"
 def info(text:str):
     current_time = datetime.datetime.now().strftime("%H:%M:%S")
     f.write(f'[{current_time}/INFO] {text}.')

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -4,19 +4,19 @@ log_path = "./Desktop/Stock/logs/info-log.txt"
 error_path = "./Desktop/Stock/logs/info-log.txt"
 def info(text:str):
     current_time = datetime.datetime.now().strftime("%H:%M:%S")
-    f.write(f'[{current_time}/INFO] {text}.')
+    f.write(f'[{current_time}/INFO] {text}')
     with open(log_path, 'a') as f:
-        f.write(f'[{current_time}/INFO] {text}.\n')
+        f.write(f'[{current_time}/INFO] {text}\n')
         f.close()
 def warn(text:str):
     current_time = datetime.datetime.now().strftime("%H:%M:%S")
-    f.write(f'[{current_time}/WARN] {text}.')
+    f.write(f'[{current_time}/WARN] {text}')
     with open(log_path, 'a') as f:
-        f.write(f'[{current_time}/WARN] {text}.\n')
+        f.write(f'[{current_time}/WARN] {text}\n')
         f.close()
 def error(text:str):
     current_time = datetime.datetime.now().strftime("%H:%M:%S")
-    f.write(f'[{current_time}/ERROR] {text}.')
+    f.write(f'[{current_time}/ERROR] {text}')
     with open(error_path, 'a') as f:
-        f.write(f'[{current_time}/ERROR] {text}.\n')
+        f.write(f'[{current_time}/ERROR] {text}\n')
         f.close()


### PR DESCRIPTION
### logger library update
This will force any info logs, warn logs, or error logs to initially be spooled to the working console.
This sets the log file paths as second priority, allowing those to soft-fail.